### PR TITLE
set global transitionDelegate to NoAnimationTransitionDelegate()

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ class MyApp extends StatelessWidget {
     listener: (state, location) {
       print("BEAMER: Beaming to ${location.state.uri}");
     },
+    transitionDelegate: NoAnimationTransitionDelegate(),
     locationBuilder: BeamerLocationBuilder(
       beamLocations: [
         HomePageLocation(),


### PR DESCRIPTION
This fixes the bloc problem, but it's a poor fix.
It seems to me that this is a deeper problem, not affecting only beamer, but entire Navigator 2.0